### PR TITLE
Fix minor spelling error

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ RAReorderableLayout
 __iOS8__  
 1. Add to your Podfile as follows.  
     use_frameworks!  
-    pod 'RAReorderableLaout'  
+    pod 'RAReorderableLayout'  
 2. pod intall  
 
 __iOS7__  


### PR DESCRIPTION
If this spelling error is not corrected, users will receive an error when they try to run pod install.  A "y" is missing from "pod 'RAReorderableLaout'" (the word Laout should have a y in it)
